### PR TITLE
Fixed Scroll amount

### DIFF
--- a/src/utils/arxivApi.ts
+++ b/src/utils/arxivApi.ts
@@ -2,7 +2,7 @@ import { ArxivQueryParams, ArxivResponse, ArxivPaper } from "../data/types";
 import { XMLParser } from "fast-xml-parser";
 
 const BASE_URL = "https://export.arxiv.org/api/query";
-const INITIAL_BATCH_SIZE = 50;
+const INITIAL_BATCH_SIZE = 500;
 
 /**
  * Converts XML response to our ArxivResponse type


### PR DESCRIPTION
This pull request includes a change to the `src/utils/arxivApi.ts` file. The change increases the `INITIAL_BATCH_SIZE` for fetching data from the Arxiv API from 50 to 500.

* [`src/utils/arxivApi.ts`](diffhunk://#diff-54d8d0f60d275cd2647045f2298580caf7d243b471c9009f2f9958b6749ccf02L5-R5): Increased `INITIAL_BATCH_SIZE` from 50 to 500 to allow fetching a larger batch of data in a single request.